### PR TITLE
chore: attest build provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
     concurrency: release
     permissions:
       id-token: write
+      attestations: write
       contents: write
 
     steps:
@@ -89,6 +90,12 @@ jobs:
         if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build build provenance
+        uses: actions/attest-build-provenance@v1
+        if: steps.release.outputs.released == 'true'
+        with:
+          subject-path: "dist/*"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos